### PR TITLE
Explicitly handle decoding of unicode characters in paths

### DIFF
--- a/src/__tests__/testUrls.js
+++ b/src/__tests__/testUrls.js
@@ -33,6 +33,10 @@ describe('Urls', () => {
         }).toThrow();
     });
 
+    it('should handle unicode params', () => {
+        expect(urls.get('user:profile', {username: 'caffè-però'})).toEqual('/u/caffè-però/');
+    });
+
     it('should generate a querystring', () => {
         expect(urls.buildSearch({})).toEqual('');
         expect(urls.buildSearch({a: 'b'})).toEqual('a=b');

--- a/src/urls.js
+++ b/src/urls.js
@@ -41,8 +41,12 @@ export default class Urls {
         if (!this._getCompileCache.hasOwnProperty(name)) {
             this._getCompileCache[name] = pathToRegexp.compile(pattern);
         }
+        // Should be a path like /jon/my-cloudcast/
+        var pathString = this._getCompileCache[name](params);
+        // Should handle unicode characters - see https://github.com/pillarjs/path-to-regexp/issues/42
+        pathString = decodeURI(pathString);
         // Replacements to undo url encoding of `+` and `:` so that discover urls look nice
-        return this._getCompileCache[name](params).replace(PLUS, '+').replace(COLON, ':');
+        return pathString.replace(PLUS, '+').replace(COLON, ':');
     }
 
     buildSearch(query: Query) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,14 +1172,6 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-create-react-class@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -2815,7 +2807,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -3076,7 +3068,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@15.6.1:
+react-dom@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
   dependencies:
@@ -3091,16 +3083,6 @@ react-test-renderer@^15.6.1:
   dependencies:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
-
-react@15.6.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
https://www.mixcloud.com/dj4play-kr/m%C3%A9tro-vol11/ became https://www.mixcloud.com/dj4play-kr/m%25C3%25A9tro-vol11/ on Cloudcast links which would lead to a 404 on Angular :sadparrot: